### PR TITLE
Adds selection range provider

### DIFF
--- a/server/plugins/index.ts
+++ b/server/plugins/index.ts
@@ -5,6 +5,7 @@ import FoldingProvider from "./folding";
 import FormattingProvider from "./formatting";
 import LinkedEditProvider from "./linkedEdit";
 import LinkProvider from "./link";
+import SelectionRangeProvider from "./range";
 import ValidationProvider from "./validation";
 import Watch from "./watch";
 
@@ -16,6 +17,7 @@ export {
   FormattingProvider,
   LinkedEditProvider,
   LinkProvider,
+  SelectionRangeProvider,
   ValidationProvider,
   Watch,
 };

--- a/server/plugins/range.test.ts
+++ b/server/plugins/range.test.ts
@@ -1,0 +1,98 @@
+import * as LSP from "vscode-languageserver/node";
+import * as Markdoc from "@markdoc/markdoc";
+import * as assert from "node:assert";
+import { test } from "node:test";
+import SelectionRangeProvider from "./range";
+
+const example1 = `
+# Example 1
+
+{% foo %}
+test
+{% /foo %}
+`;
+
+const example2 = `
+# Example 2
+
+{% foo %}
+{% bar %}
+test
+
+{% baz %}
+test
+{% /baz %}
+{% /bar %}
+
+test
+{% /foo %}
+`;
+
+const connectionMock = { onSelectionRanges(...args) {} };
+
+test("folding provider", async (t) => {
+  // @ts-expect-error
+  const provider = new SelectionRangeProvider({}, connectionMock, {});
+
+  await t.test("simple example", () => {
+    const ast = Markdoc.parse(example1);
+    const range = provider.findSelectionRange(ast, LSP.Position.create(4, 3));
+    assert.deepEqual(range, {
+      parent: {
+        parent: undefined,
+        range: {
+          start: { line: 3, character: 0 },
+          end: { line: 6, character: 0 },
+        },
+      },
+      range: {
+        start: { line: 4, character: 0 },
+        end: { line: 5, character: 0 },
+      },
+    });
+  });
+
+  await t.test("nested example", () => {
+    const ast = Markdoc.parse(example2);
+    const range = provider.findSelectionRange(ast, LSP.Position.create(8, 3));
+    const expected = {
+      parent: {
+        parent: {
+          parent: {
+            parent: {
+              parent: {
+                parent: undefined,
+                range: {
+                  start: { line: 3, character: 0 },
+                  end: { line: 14, character: 0 },
+                },
+              },
+              range: {
+                start: { line: 4, character: 0 },
+                end: { line: 13, character: 0 },
+              },
+            },
+            range: {
+              start: { line: 4, character: 0 },
+              end: { line: 11, character: 0 },
+            },
+          },
+          range: {
+            start: { line: 5, character: 0 },
+            end: { line: 10, character: 0 },
+          },
+        },
+        range: {
+          start: { line: 7, character: 0 },
+          end: { line: 10, character: 0 },
+        },
+      },
+      range: {
+        start: { line: 8, character: 0 },
+        end: { line: 9, character: 0 },
+      },
+    };
+
+    assert.deepEqual(range, expected);
+  });
+});

--- a/server/plugins/range.ts
+++ b/server/plugins/range.ts
@@ -1,0 +1,46 @@
+import * as LSP from "vscode-languageserver/node";
+import * as utils from "../utils";
+import type { Config, ServiceInstances } from "../types";
+import type * as Markdoc from "@markdoc/markdoc";
+
+export default class SelectionRangeProvider {
+  constructor(
+    protected config: Config,
+    protected connection: LSP.Connection,
+    protected services: ServiceInstances
+  ) {
+    connection.onSelectionRanges(this.onSelectionRange.bind(this));
+  }
+
+  register(registration: LSP.BulkRegistration) {
+    registration.add(LSP.SelectionRangeRequest.type, {
+      documentSelector: null,
+    });
+  }
+
+  findSelectionRange(ast: Markdoc.Node, position: LSP.Position) {
+    let currentRange: LSP.SelectionRange | undefined;
+    for (const range of utils.getBlockRanges(ast)) {
+      if (range.start > position.line) break;
+      if (range.end > position.line) {
+        currentRange = {
+          range: LSP.Range.create(range.start + 1, 0, range.end, 0),
+          parent: {
+            range: LSP.Range.create(range.start, 0, range.end + 1, 0),
+            parent: currentRange,
+          },
+        };
+      }
+    }
+
+    return currentRange ?? { range: LSP.Range.create(position, position) };
+  }
+
+  onSelectionRange({ textDocument, positions }: LSP.SelectionRangeParams) {
+    const ast = this.services.Documents.ast(textDocument.uri);
+    if (ast)
+      return positions.map((position) =>
+        this.findSelectionRange(ast, position)
+      );
+  }
+}

--- a/server/plugins/validation.ts
+++ b/server/plugins/validation.ts
@@ -36,10 +36,11 @@ export default class ValidationProvider {
     } = err;
 
     return {
+      code: error.id,
       range: this.createRange(line, error.location ?? location),
       severity: this.severity(error.level),
       message: error.message,
-      source: `markdoc ${this.config.id ?? ""}`,
+      source: `markdoc:${this.config.id ?? ""}`,
     };
   }
 


### PR DESCRIPTION
- Adds a selection range provider that matches against Markdoc tags and tag interiors in order to support the "expand selection" command with behavior similar to what VSCode already provides for HTML tags
- Adds test cases for the selection range provider that verify the correctness of the implementation
- Modifies the validation provider so that it shows the validation error ID as the error code in the "problems" panel table view