### PR TITLE
Adds a dedicated markdoc language id

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ The JSON configuration file consists of an array of server instance descriptions
   - The `routing` property is an optional object that describes your project's routing configuration
     - The `frontmatter` property is a string that tells the extension which property in the Markdoc file's YAML frontmatter contains the URL route associated with the file
 
+### File extensions
+
+In order to distinguish Markdoc files from Markdown files, the Visual Studio Code extension expects Markdoc files to use one of the following file extensions: `.markdoc`, `.markdoc.md`, or `.mdoc`.
+
+It does **not** recognize `.md` files by default. If you would like to still use a `.md` extension, you can instead modify your Visual Studio Code workspace configuration with a custom file association. Add the following content to your `.vscode/settings.json` file:
+
+```
+{
+  "files.associations": {
+    "*.md": "markdoc"
+  }
+}
+```
+
+### Advanced configuration
+
 It is possible to have multiple Markdoc configurations for the same workspace by adding additional configuration objects to the top-level array. This is useful in cases where you have multiple websites with different schemas under different subdirectories of the same workspace. For example, you might want separate configurations for narrative documentation and an API reference.
 
 In [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces), a Markdoc configuration file is specific to an individual workspace root. You can have separate Markdoc configuration files for each root. If you need to override the location of the Markdoc language server configuration file in a multi-root workspace, you can use a [folder setting](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_settings) to customize this behavior per root.

--- a/client/client.ts
+++ b/client/client.ts
@@ -97,7 +97,7 @@ export default class MarkdocClient implements VSC.Disposable {
     const pattern = pathutil.join(fsPath, config.path, "**/*.{md,mdoc}");
     const client: LSP.LanguageClientOptions = {
       initializationOptions: { config },
-      documentSelector: [{ language: "markdown", scheme, pattern }],
+      documentSelector: [{ language: "markdoc", scheme, pattern }],
       markdown: { isTrusted: true },
     };
 

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -126,7 +126,7 @@ export default class Extension {
 
   async onActive(editor?: VSC.TextEditor) {
     if (!editor) return;
-    if (editor.document.languageId !== "markdown") return this.setActive();
+    if (editor.document.languageId !== "markdoc") return this.setActive();
 
     const { uri } = editor.document;
     const client = this.findClient(uri);
@@ -170,7 +170,7 @@ export default class Extension {
     const content = new TextDecoder().decode(raw);
     const doc = await VSC.workspace.openTextDocument({
       content,
-      language: "markdown",
+      language: "markdoc",
     });
 
     VSC.window.showTextDocument(doc);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
-  "name": "markdoc-language-server",
-  "version": "0.0.1",
+  "name": "markdoc-language-support",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
+      "name": "markdoc-language-support",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.11.18",
+        "@vscode/vsce": "^2.19.0",
         "esbuild": "0.17.17",
         "esbuild-register": "^3.4.2",
-        "typescript": "^4.9.3",
-        "vsce": "^2.15.0"
+        "typescript": "^4.9.3"
       },
       "engines": {
         "vscode": "^1.63.0"
@@ -376,6 +377,56 @@
       "integrity": "sha512-sMo3EngB6QkMBlB9rBe1lFdKSLqljyWPPWv6/FzSxh/IDlyVWSzE9RiF4eAuerQHybrWdqBgAGb03PM89qOasA==",
       "dev": true
     },
+    "node_modules/@vscode/vsce": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.19.0.tgz",
+      "integrity": "sha512-dAlILxC5ggOutcvJY24jxz913wimGiUrHaPkk16Gm9/PGFbz1YezWtrXsTKUtJws4fIlpX2UIlVlVESWq8lkfQ==",
+      "dev": true,
+      "dependencies": {
+        "azure-devops-node-api": "^11.0.1",
+        "chalk": "^2.4.2",
+        "cheerio": "^1.0.0-rc.9",
+        "commander": "^6.1.0",
+        "glob": "^7.0.6",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^12.3.2",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.3",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "semver": "^5.1.0",
+        "tmp": "^0.2.1",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^2.3.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -428,13 +479,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -476,6 +529,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -559,7 +613,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -641,6 +696,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -656,6 +712,7 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -665,6 +722,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -729,6 +787,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -808,6 +867,7 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -825,7 +885,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -858,7 +919,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -974,7 +1036,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -996,6 +1059,13 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "node_modules/keytar": {
@@ -1004,6 +1074,7 @@
       "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
       "dev": true,
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^4.3.0",
         "prebuild-install": "^7.0.1"
@@ -1087,6 +1158,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -1111,6 +1183,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1119,7 +1192,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1137,13 +1211,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/node-abi": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz",
       "integrity": "sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1156,6 +1232,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
       "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1170,7 +1247,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -1256,6 +1334,7 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
       "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -1282,6 +1361,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -1307,6 +1387,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -1334,6 +1415,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1376,7 +1458,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/sax": {
       "version": "1.2.4",
@@ -1425,7 +1508,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -1446,6 +1530,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -1457,6 +1542,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -1466,6 +1552,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1487,6 +1574,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -1499,6 +1587,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -1536,6 +1625,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -1589,61 +1679,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
-    },
-    "node_modules/vsce": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.15.0.tgz",
-      "integrity": "sha512-P8E9LAZvBCQnoGoizw65JfGvyMqNGlHdlUXD1VAuxtvYAaHBKLBdKPnpy60XKVDAkQCfmMu53g+gq9FM+ydepw==",
-      "deprecated": "vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.",
       "dev": true,
-      "dependencies": {
-        "azure-devops-node-api": "^11.0.1",
-        "chalk": "^2.4.2",
-        "cheerio": "^1.0.0-rc.9",
-        "commander": "^6.1.0",
-        "glob": "^7.0.6",
-        "hosted-git-info": "^4.0.2",
-        "keytar": "^7.7.0",
-        "leven": "^3.1.0",
-        "markdown-it": "^12.3.2",
-        "mime": "^1.3.4",
-        "minimatch": "^3.0.3",
-        "parse-semver": "^1.1.1",
-        "read": "^1.0.7",
-        "semver": "^5.1.0",
-        "tmp": "^0.2.1",
-        "typed-rest-client": "^1.8.4",
-        "url-join": "^4.0.1",
-        "xml2js": "^0.4.23",
-        "yauzl": "^2.3.1",
-        "yazl": "^2.2.2"
-      },
-      "bin": {
-        "vsce": "vsce"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
+      "optional": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/xmlbuilder": {
       "version": "11.0.1",

--- a/package.json
+++ b/package.json
@@ -79,26 +79,21 @@
       "editor/title": [
         {
           "command": "markdoc.preview",
-          "when": "resourceLangId == markdown && markdoc.enabled && markdoc.canPreview",
+          "when": "resourceLangId == markdoc && markdoc.enabled && markdoc.canPreview",
           "group": "navigation"
         }
       ]
     },
     "languages": [
       {
-        "id": "source.markup.markdoc",
+        "id": "markdoc",
         "aliases": [
-          "Markdoc"
-        ]
-      },
-      {
-        "id": "markdown",
-        "aliases": [
-          "Markdown",
-          "markdown"
+          "Markdoc",
+          "markdoc"
         ],
         "extensions": [
-          ".md",
+          ".markdoc",
+          ".markdoc.md",
           ".mdoc"
         ],
         "configuration": "./language-configuration.json"
@@ -106,21 +101,18 @@
     ],
     "grammars": [
       {
-        "language": "source.markup.markdoc",
-        "scopeName": "source.markup.markdoc",
-        "path": "./syntaxes/markdoc.tmLanguage.json",
-        "embeddedLanguages": {
-          "meta.embedded.inline.json": "json"
-        }
+        "language": "markdoc",
+        "scopeName": "text.html.markdown.markdoc",
+        "path": "./syntaxes/markdoc.tmLanguage.json"
       },
       {
         "injectTo": [
-          "text.html.markdown"
+          "text.html.markdown",
+          "source.markup.markdoc"
         ],
-        "scopeName": "text.html.markdown.markdoc",
+        "scopeName": "text.html.markdown.markdoc.injection",
         "path": "./syntaxes/markdoc.markdown.tmLanguage.json",
         "embeddedLanguages": {
-          "meta.embedded.markdoc": "source.markup.markdoc",
           "meta.embedded.inline.json": "json"
         }
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "esbuild": "0.17.17",
     "esbuild-register": "^3.4.2",
     "typescript": "^4.9.3",
-    "vsce": "^2.15.0"
+    "@vscode/vsce": "^2.19.0"
   },
   "activationEvents": [],
   "contributes": {

--- a/server/plugins/formatting.test.ts
+++ b/server/plugins/formatting.test.ts
@@ -26,7 +26,7 @@ const mockConnection = {
 };
 
 function mockDoc(content: string) {
-  return TextDocument.create("file:///content.md", "markdown", 0, content);
+  return TextDocument.create("file:///content.md", "markdoc", 0, content);
 }
 
 test("formatting provider", async (t) => {

--- a/syntaxes/markdoc.markdown.tmLanguage.json
+++ b/syntaxes/markdoc.markdown.tmLanguage.json
@@ -1,6 +1,36 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "scopeName": "text.html.markdown.markdoc",
-  "injectionSelector": "L:text.html.markdown",
-  "patterns": [{ "include": "source.markup.markdoc" }]
+  "scopeName": "text.html.markdown.markdoc.injection",
+  "injectionSelector": ["L:text.html.markdown", "L:text.html.markdown.markdoc"],
+  "patterns": [{ "include": "#tag" }],
+  "repository": {
+    "shortcut": {
+      "match": "(\\$|\\.|#)([-_:a-zA-Z0-9]+)",
+      "name": "string.other.markdoc-shortcut"
+    },
+    "attribute": {
+      "match": "([-_a-zA-Z0-9]+)(=)",
+      "captures": {
+        "1": { "name": "entity.other.attribute-name" },
+        "2": { "name": "punctuation.definition.tag.equal.markdoc" }
+      }
+    },
+    "tag": {
+      "name": "punctuation.definition.tag",
+      "begin": "({%)\\s*/?([-_a-zA-Z0-9]+)?",
+      "end": "\\s*/?\\s*%}",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.tag.begin.markdoc" },
+        "2": { "name": "entity.name.tag" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.tag.end.markdoc" }
+      },
+      "patterns": [
+        { "include": "#attribute" },
+        { "include": "#shortcut" },
+        { "include": "source.json" }
+      ]
+    }
+  }
 }

--- a/syntaxes/markdoc.tmLanguage.json
+++ b/syntaxes/markdoc.tmLanguage.json
@@ -1,36 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "source.markup.markdoc",
-  "scopeName": "source.markup.markdoc",
-  "patterns": [{ "include": "#tag" }],
-  "repository": {
-    "shortcut": {
-      "match": "(\\$|\\.|#)([-_:a-zA-Z0-9]+)",
-      "name": "string.other.markdoc-shortcut"
-    },
-    "attribute": {
-      "match": "([-_a-zA-Z0-9]+)(=)",
-      "captures": {
-        "1": { "name": "entity.other.attribute-name" },
-        "2": { "name": "punctuation.definition.tag.equal.markdoc" }
-      }
-    },
-    "tag": {
-      "name": "punctuation.definition.tag",
-      "begin": "({%)\\s*/?([-_a-zA-Z0-9]+)?",
-      "end": "\\s*/?\\s*%}",
-      "beginCaptures": {
-        "1": { "name": "punctuation.definition.tag.begin.markdoc" },
-        "2": { "name": "entity.name.tag" }
-      },
-      "endCaptures": {
-        "0": { "name": "punctuation.definition.tag.end.markdoc" }
-      },
-      "patterns": [
-        { "include": "#attribute" },
-        { "include": "#shortcut" },
-        { "include": "source.json" }
-      ]
-    }
-  }
+  "name": "markdoc",
+  "scopeName": "text.html.markdown.markdoc",
+  "patterns": [{ "include": "text.html.markdown" }]
 }


### PR DESCRIPTION
Microsoft's own Markdown language server conflicts with the Markdoc language server in a number of places. These conflicts could worsen as they introduce additional features. To address the issue, this PR changes the Markdoc VSCode extension to introduce a dedicated "markdoc" language identifier that is distinct from the "markdown" language identifier. This makes it so that the Markdown language server does not operate on Markdoc files.

In order to make this work, we need to use a separate file extensions to uniquely distinguish Markdoc files from Markdown files. This PR establishes `.mdoc`, `.markdoc`, and `.markdoc.md` as valid file extensions for Markdoc content. The PR also updates the README file to describe this change and demonstrate how users who still want to be able to use the `.md` extension with Markdoc content can create a manual file association in their workspace settings.

The PR also modifies the syntax highlighting slightly in order to compensate for these changes. It is set up so that it still injects highlighting for the Markdoc tag syntax into Markdown files as well as Markdoc files.