### PR TITLE
Fixes invalid ranges from `getContentRangeInLine`

### DIFF
--- a/server/plugins/link.ts
+++ b/server/plugins/link.ts
@@ -33,7 +33,7 @@ export default class LinkProvider {
         if (!relative) continue;
 
         const range = utils.getContentRangeInLine(node.lines[0], doc, href);
-        links.push({ target: Scanner.fullPath(relative), range });
+        if (range) links.push({ target: Scanner.fullPath(relative), range });
         continue;
       }
 
@@ -42,7 +42,7 @@ export default class LinkProvider {
         if (typeof file !== "string") continue;
 
         const range = utils.getContentRangeInLine(node.lines[0], doc, file);
-        links.push({ target: Scanner.fullPath(file), range });
+        if (range) links.push({ target: Scanner.fullPath(file), range });
       }
     }
 

--- a/server/plugins/linkedEdit.ts
+++ b/server/plugins/linkedEdit.ts
@@ -26,11 +26,12 @@ export default class LinkedEditProvider {
     const ast = this.services.Documents.ast(params.textDocument.uri);
     if (!ast || !doc) return;
 
-    for (const { start, end, tag } of utils.getBlockRanges(ast))
+    for (const { start, end, tag } of utils.getBlockRanges(ast)) {
       if (tag && [start, end].includes(params.position.line)) {
         const open = utils.getContentRangeInLine(start, doc, tag);
         const close = utils.getContentRangeInLine(end, doc, tag);
-        return { ranges: [open, close] };
+        if (open && close) return { ranges: [open, close] };
       }
+    }
   }
 }

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -24,10 +24,13 @@ export function getContentRangeInLine(
   doc: TextDocument,
   text: string
 ) {
+  if (typeof line !== "number" || line < 0) return null;
   const lineContent = doc.getText(LSP.Range.create(line, 0, line + 1, 0));
   const startOffset = lineContent.indexOf(text);
   const endOffset = startOffset + text.length;
-  return LSP.Range.create(line, startOffset, line, endOffset);
+  return startOffset < 0
+    ? null
+    : LSP.Range.create(line, startOffset, line, endOffset);
 }
 
 export function* getBlockRanges(ast: Markdoc.Node) {


### PR DESCRIPTION
In cases where the document is malformed due to unmatched opening and closing ranges, the `getContentRangeInLine` function would fail to find the `startIndex` of the desired content, resulting in `Range.create` invocations with `-1` for the character position.

This PR makes the `getContentRangeInLine` function explicitly check to make sure that line and character values are valid, returning `null` when they are not. It also updates all the call sites in the `LinkProvider` and `LinkedEditProvider` to make sure that they gracefully handle these cases.