### PR TITLE
Rpaul markdoc 030

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "Markdoc Extension",
   "author": "Ryan Paul",
   "license": "MIT",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "scripts": {
     "build": "esbuild index.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs",
     "build:server": "esbuild server.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Ryan Paul",
   "publisher": "stripe",
   "license": "MIT",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A Markdoc language server and Visual Studio Code extension",
   "repository": {
     "type": "git",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@markdoc/language-server",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/language-server",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "MIT",
       "devDependencies": {
-        "@markdoc/markdoc": "^0.2.1",
+        "@markdoc/markdoc": "^0.3.0",
         "@types/picomatch": "^2.3.0",
         "picomatch": "^2.3.1",
         "typescript": "^5.0.4",
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@markdoc/markdoc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.2.2.tgz",
-      "integrity": "sha512-0TiD9jmA5h5znN4lxo7HECAu3WieU5g5vUsfByeucrdR/x88hEilpt16EydFyJwJddQ/3w5HQgW7Ovy62r4cyw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.3.0.tgz",
+      "integrity": "sha512-QWCF8krIIw52ulflfnoff0yG1eKl9CCGA3KAiOjHyYtHNzSEouFh8lO52nAaO3qV2Ctj1GTB8TTb2rTfvISQfA==",
       "dev": true,
       "engines": {
         "node": ">=14.7.0"

--- a/server/package.json
+++ b/server/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/language-server",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A Markdoc language server",
   "main": "dist/index.js",
   "author": "Ryan Paul",
   "license": "MIT",
   "devDependencies": {
-    "@markdoc/markdoc": "^0.2.1",
+    "@markdoc/markdoc": "^0.3.0",
     "@types/picomatch": "^2.3.0",
     "picomatch": "^2.3.1",
     "typescript": "^5.0.4",

--- a/server/plugins/completion.ts
+++ b/server/plugins/completion.ts
@@ -93,7 +93,6 @@ export default class CompletionProvider {
         insertText: item.data.block ? text : text.replaceAll("\n", ""),
         insertTextFormat: LSP.InsertTextFormat.Snippet,
         kind: LSP.CompletionItemKind.Function,
-        // @ts-expect-error
         documentation: config.description ?? "",
       };
     },

--- a/server/plugins/formatting.test.ts
+++ b/server/plugins/formatting.test.ts
@@ -13,11 +13,11 @@ const example1 = `
 const example1Formatted = `
 # This is a test {% #foo %}
 
-- This is an example [foo](/bar)
+* This is an example [foo](/bar)
 `;
 
 const example1LastLine = `
-- This is an example [foo](/bar)
+* This is an example [foo](/bar)
 `;
 
 const mockConnection = {

--- a/server/plugins/formatting.ts
+++ b/server/plugins/formatting.ts
@@ -30,7 +30,7 @@ export default class FormattingProvider {
       : LSP.Range.create(0, 0, doc.lineCount, 0);
 
     const text = doc.getText(actualRange);
-    const ast = Markdoc.parse(text);
+    const ast = Markdoc.parse(text, { slots: this.config.markdoc?.slots });
     const output = Markdoc.format(ast);
 
     return [LSP.TextEdit.replace(actualRange, output)];

--- a/server/plugins/formatting.ts
+++ b/server/plugins/formatting.ts
@@ -5,11 +5,14 @@ import type { Config, ServiceInstances } from "../types";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 export default class FormattingProvider {
+  protected tokenizer: Markdoc.Tokenizer;
+
   constructor(
     protected config: Config,
     protected connection: LSP.Connection,
     protected services: ServiceInstances
   ) {
+    this.tokenizer = new Markdoc.Tokenizer(config.markdoc ?? {});
     connection.onDocumentFormatting(this.onDocumentFormatting.bind(this));
     connection.onDocumentRangeFormatting(this.onRangeFormatting.bind(this));
   }
@@ -30,7 +33,8 @@ export default class FormattingProvider {
       : LSP.Range.create(0, 0, doc.lineCount, 0);
 
     const text = doc.getText(actualRange);
-    const ast = Markdoc.parse(text, { slots: this.config.markdoc?.slots });
+    const tokens = this.tokenizer.tokenize(text);
+    const ast = Markdoc.parse(tokens, { slots: this.config.markdoc?.slots });
     const output = Markdoc.format(ast);
 
     return [LSP.TextEdit.replace(actualRange, output)];

--- a/server/services/documents.ts
+++ b/server/services/documents.ts
@@ -27,7 +27,7 @@ export default class Documents<
 
   parse(content: string, file: string) {
     const tokens = this.tokenizer.tokenize(content);
-    return Markdoc.parse(tokens, file);
+    return Markdoc.parse(tokens, { file, slots: this.config.markdoc?.slots });
   }
 
   protected handleClose({ document }: TextChangeEvent) {

--- a/server/services/scanner.ts
+++ b/server/services/scanner.ts
@@ -75,7 +75,7 @@ export default class Scanner<
 
   parse(content: string, file: string) {
     const tokens = this.tokenizer.tokenize(content);
-    return Markdoc.parse(tokens, file);
+    return Markdoc.parse(tokens, { file, slots: this.config.markdoc?.slots });
   }
 
   async scan() {


### PR DESCRIPTION
- Updates the language server to use Markdoc 0.3.0
- Makes the formatting provider respect Markdoc parsing configuration
- Modifies the formatting provider test cases to account for the parser retaining the list symbol
- Adds support for enabling [slots](https://github.com/markdoc/markdoc/discussions/342)
