### PR TITLE
Automatically update preview on save

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "Markdoc Extension",
   "author": "Ryan Paul",
   "license": "MIT",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "scripts": {
     "build": "esbuild index.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs",
     "build:server": "esbuild server.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Ryan Paul",
   "publisher": "stripe",
   "license": "MIT",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Markdoc language server and Visual Studio Code extension",
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdoc/language-server",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Markdoc language server",
   "main": "dist/index.js",
   "author": "Ryan Paul",


### PR DESCRIPTION
- Extracts extension preview update logic into dedicated function in `extension.ts`
- Adds workspace `onDidSaveTextDocument` handler to the extension that updates the preview when a Markdoc document is saved if a preview exists
- Modifies the extension's language server loading logic so that it gracefully falls back to the built-in language server if the path to a custom language server points to a non-existent file
- increments the version number of the language server and extension for a new release