### PR TITLE
Adds table converter code action

### DIFF
--- a/server/plugins/codeaction.ts
+++ b/server/plugins/codeaction.ts
@@ -1,0 +1,39 @@
+import * as LSP from "vscode-languageserver/node";
+import * as Markdoc from "@markdoc/markdoc";
+
+import type { Config, ServiceInstances } from "../types";
+
+export default class CodeActionProvider {
+  constructor(
+    protected config: Config,
+    protected connection: LSP.Connection,
+    protected services: ServiceInstances
+  ) {
+    connection.onCodeAction(this.onCodeAction.bind(this));
+  }
+  
+  register(registration: LSP.BulkRegistration) {
+    registration.add(LSP.CodeActionRequest.type, {documentSelector: null});
+  }
+
+  findTables(ast: Markdoc.Node, params: LSP.CodeActionParams): LSP.Command[] {
+    const output: LSP.Command[] = []; 
+    const {line} = params.range.start;
+    const {uri} = params.textDocument;
+    
+    for (const node of ast.walk())
+      if (node.type === 'table' && node.lines.includes(line))
+        output.push({
+          command: 'markdoc.convertTable',
+          title: 'Convert to Markdoc Table',
+          arguments: [uri, line]
+        });
+
+    return output;
+  }
+
+  onCodeAction(params: LSP.CodeActionParams): (LSP.CodeAction | LSP.Command)[] {
+    const ast = this.services.Documents.ast(params.textDocument.uri);
+    return ast ? this.findTables(ast, params) : [];
+  }
+}

--- a/server/plugins/formatting.test.ts
+++ b/server/plugins/formatting.test.ts
@@ -31,11 +31,10 @@ function mockDoc(content: string) {
 
 test("formatting provider", async (t) => {
   // @ts-expect-error
-  const provider = new FormattingProvider({}, mockConnection, {});
+  const provider = new FormattingProvider({}, mockConnection, {Commands: {add(...args: any) {}}});
 
   await t.test("simple full-text formatting", () => {
     const doc = mockDoc(example1);
-    // @ts-expect-error
     const [output] = provider.formatRange(doc);
     assert.strictEqual(output.newText.trim(), example1Formatted.trim());
   });

--- a/server/plugins/index.ts
+++ b/server/plugins/index.ts
@@ -1,3 +1,4 @@
+import CodeActionProvider from "./codeaction";
 import CompletionProvider from "./completion";
 import DefinitionProvider from "./definition";
 import DependenciesProvider from "./dependencies";
@@ -10,6 +11,7 @@ import ValidationProvider from "./validation";
 import Watch from "./watch";
 
 export {
+  CodeActionProvider,
   CompletionProvider,
   DefinitionProvider,
   DependenciesProvider,


### PR DESCRIPTION
- Adds a command for converting tables into Markdoc tables
- Adds a `CodeAction` provider plugin to the language server
- Adds a code action that detects GFM tables and offers to convert them to Markdoc tables