### PR TITLE
Adds symbol provider

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "Markdoc Extension",
   "author": "Ryan Paul",
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "scripts": {
     "build": "esbuild index.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs",
     "build:server": "esbuild server.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Ryan Paul",
   "publisher": "stripe",
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A Markdoc language server and Visual Studio Code extension",
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdoc/language-server",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A Markdoc language server",
   "main": "dist/index.js",
   "author": "Ryan Paul",

--- a/server/plugins/index.ts
+++ b/server/plugins/index.ts
@@ -7,6 +7,7 @@ import FormattingProvider from "./formatting";
 import LinkedEditProvider from "./linkedEdit";
 import LinkProvider from "./link";
 import SelectionRangeProvider from "./range";
+import SymbolProvider from "./symbols";
 import ValidationProvider from "./validation";
 import Watch from "./watch";
 
@@ -20,6 +21,7 @@ export {
   LinkedEditProvider,
   LinkProvider,
   SelectionRangeProvider,
+  SymbolProvider,
   ValidationProvider,
   Watch,
 };

--- a/server/plugins/symbols.ts
+++ b/server/plugins/symbols.ts
@@ -1,0 +1,58 @@
+import * as LSP from "vscode-languageserver/node";
+import { toPlainText } from "../utils";
+import type { Config, ServiceInstances } from "../types";
+import type * as Markdoc from "@markdoc/markdoc";
+
+export default class SymbolProvider {
+  constructor(
+    protected config: Config,
+    protected connection: LSP.Connection,
+    protected services: ServiceInstances
+  ) {
+    connection.onDocumentSymbol(this.onDocumentSymbol.bind(this));
+  }
+
+  register(registration: LSP.BulkRegistration) {
+    registration.add(LSP.DocumentSymbolRequest.type, {
+      documentSelector: null,
+    });
+  }
+
+  headings(node: Markdoc.Node) {
+    let stack: Array<Partial<LSP.DocumentSymbol> & { level: number }> =
+      [{ level: 0, children: [] }];
+
+    for (const child of node.walk()) {
+      if (child.type !== "heading" || typeof child.attributes.level !== 'number')
+        continue;
+
+      const [start, finish] = child.lines;
+      if (!start || !finish) continue;
+
+      const range = LSP.Range.create(start, 0, finish + 1, 0);
+      const entry = {
+        name: `${"#".repeat(child.attributes.level)} ${toPlainText(child)}`,
+        level: child.attributes.level,
+        kind: LSP.SymbolKind.Key,
+        range,
+        selectionRange: range,
+        children: [],
+      };
+
+      while (entry.level <= stack[stack.length - 1].level)
+        stack.pop();
+
+      stack[stack.length - 1].children?.push(entry);
+
+      if (entry.level > stack[stack.length - 1].level)
+        stack.push(entry);
+    }
+
+    return stack[0].children;
+  }
+
+  onDocumentSymbol({ textDocument }: LSP.DocumentSymbolParams) {
+    const ast = this.services.Documents.ast(textDocument.uri);
+    return ast && this.headings(ast);
+  }
+}

--- a/server/services/schema.ts
+++ b/server/services/schema.ts
@@ -1,6 +1,6 @@
 import * as LSP from "vscode-languageserver/node";
 import * as pathutil from "path";
-import type * as Markdoc from "@markdoc/markdoc";
+import * as Markdoc from "@markdoc/markdoc";
 import type { Config } from "../types";
 
 export default class Schema<TConfig extends Config = Config> {
@@ -17,7 +17,26 @@ export default class Schema<TConfig extends Config = Config> {
   }
 
   async reload() {
-    this.schema = await this.load();
+    const schema = await this.load();
+    this.schema = schema && this.merge(schema);
+  }
+
+  merge(config: Markdoc.Config) {
+    return {
+      ...config,
+      tags: {
+        ...Markdoc.tags,
+        ...config.tags,
+      },
+      nodes: {
+        ...Markdoc.nodes,
+        ...config.nodes,
+      },
+      functions: {
+        ...Markdoc.functions,
+        ...config.functions,
+      },
+    };
   }
 
   async load(): Promise<Markdoc.Config | undefined> {

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -19,6 +19,15 @@ export async function* findFiles(
   }
 }
 
+export function toPlainText(node: Markdoc.Node): string {
+  let output = "";
+  for (const child of node.walk())
+    if (child.type === "text")
+      output += child.attributes.content;
+
+  return output;
+}
+
 export function getContentRangeInLine(
   line: number,
   doc: TextDocument,


### PR DESCRIPTION
- Increments the version number for a new release
- Adds a new symbol provider plugin that shows the document headings in the outline pane
- Adds schema merging logic to the schema service so that built-in tags are properly supported in auto-completion (Thanks to @louiss0 for reporting this issue)