### PR TITLE
Updates to Markdoc 0.3.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "Markdoc Extension",
   "author": "Ryan Paul",
   "license": "MIT",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "scripts": {
     "build": "esbuild index.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs",
     "build:server": "esbuild server.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Ryan Paul",
   "publisher": "stripe",
   "license": "MIT",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A Markdoc language server and Visual Studio Code extension",
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/language-server",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A Markdoc language server",
   "main": "dist/index.js",
   "author": "Ryan Paul",
   "license": "MIT",
   "devDependencies": {
-    "@markdoc/markdoc": "^0.3.0",
+    "@markdoc/markdoc": "^0.3.2",
     "@types/picomatch": "^2.3.0",
     "picomatch": "^2.3.1",
     "typescript": "^5.0.4",


### PR DESCRIPTION
Updates the language server to use Markdoc [0.3.2](https://github.com/markdoc/markdoc/releases/tag/0.3.2) so that it gets the latest functionality.