### PR TITLE
Use a resolver for table conversion

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
-        "@markdoc/markdoc": "^0.3.2",
+        "@markdoc/markdoc": "^0.3.3",
         "@types/picomatch": "^2.3.0",
         "picomatch": "^2.3.1",
         "typescript": "^5.0.4",
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@markdoc/markdoc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.3.2.tgz",
-      "integrity": "sha512-D0SaanaSkTIARvQu+zQqPEpKcvYUBR/mfac9e8JzS89P7eXhiNWPonUN7avRS1saZHpIQWIRote97qT+jGk5Gw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.3.3.tgz",
+      "integrity": "sha512-z9vd8KO914o7vd+ojxnOHxvDXDE2nPNexyLFCl5wxKmqbg9SE6JyrtnFs0rOdliOgXqWctev0eg60qQsi2vdGA==",
       "dev": true,
       "engines": {
         "node": ">=14.7.0"

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "author": "Ryan Paul",
   "license": "MIT",
   "devDependencies": {
-    "@markdoc/markdoc": "^0.3.2",
+    "@markdoc/markdoc": "^0.3.3",
     "@types/picomatch": "^2.3.0",
     "picomatch": "^2.3.1",
     "typescript": "^5.0.4",

--- a/server/plugins/codeaction.ts
+++ b/server/plugins/codeaction.ts
@@ -10,23 +10,38 @@ export default class CodeActionProvider {
     protected services: ServiceInstances
   ) {
     connection.onCodeAction(this.onCodeAction.bind(this));
+    connection.onCodeActionResolve(this.onCodeActionResolve.bind(this));
   }
   
   register(registration: LSP.BulkRegistration) {
-    registration.add(LSP.CodeActionRequest.type, {documentSelector: null});
+    registration.add(LSP.CodeActionRequest.type, {documentSelector: null, resolveProvider: true});
   }
 
-  findTables(ast: Markdoc.Node, params: LSP.CodeActionParams): LSP.Command[] {
-    const output: LSP.Command[] = []; 
+  convertTable(uri: string, line: number): LSP.WorkspaceEdit | void {
+    const ast = this.services.Documents.ast(uri);
+    if (!ast) return;
+
+    for (const node of ast.walk()) {
+      if (node.type === 'table' && node.lines.includes(line)) {
+        const content = new Markdoc.Ast.Node('tag', {}, [node], 'table');
+        const newText = Markdoc.format(content);
+        const [start, end] = node.lines;
+        const range = LSP.Range.create(start, 0, end + 1, 0);
+        return {changes: {[uri]: [{range, newText}]}};
+      }
+    }
+  }
+
+  findTables(ast: Markdoc.Node, params: LSP.CodeActionParams): LSP.CodeAction[] {
+    const output: LSP.CodeAction[] = []; 
     const {line} = params.range.start;
     const {uri} = params.textDocument;
     
     for (const node of ast.walk())
       if (node.type === 'table' && node.lines.includes(line))
         output.push({
-          command: 'markdoc.convertTable',
+          data: {type: 'convertTable', uri, line},
           title: 'Convert to Markdoc Table',
-          arguments: [uri, line]
         });
 
     return output;
@@ -35,5 +50,15 @@ export default class CodeActionProvider {
   onCodeAction(params: LSP.CodeActionParams): (LSP.CodeAction | LSP.Command)[] {
     const ast = this.services.Documents.ast(params.textDocument.uri);
     return ast ? this.findTables(ast, params) : [];
+  }
+
+  onCodeActionResolve(action: LSP.CodeAction): LSP.CodeAction {
+    if (action.data.type === 'convertTable') {
+      const {uri, line} = action.data;
+      const edit = this.convertTable(uri, line);
+      if (edit) return {...action, edit};
+    }
+
+    return action;
   }
 }

--- a/server/plugins/formatting.ts
+++ b/server/plugins/formatting.ts
@@ -15,7 +15,6 @@ export default class FormattingProvider {
     this.tokenizer = new Markdoc.Tokenizer(config.markdoc ?? {});
     connection.onDocumentFormatting(this.onDocumentFormatting.bind(this));
     connection.onDocumentRangeFormatting(this.onRangeFormatting.bind(this));
-    services.Commands.add('markdoc.convertTable', this.convertTable.bind(this));
   }
 
   register(registration: LSP.BulkRegistration) {

--- a/server/plugins/validation.ts
+++ b/server/plugins/validation.ts
@@ -78,7 +78,15 @@ export default class ValidationProvider {
       if (Scanner.has(part.attributes.file))
         partials[part.attributes.file] = true;
 
-    return { ...Schema?.get(uri), partials };
+    const schema = Schema?.get(uri);
+    return {
+      ...schema,
+      partials,
+      validation: {
+        environment: 'language-server',
+        ...schema?.validation
+      }
+    };
   }
 
   onDidSave({ document: { uri } }: TextChangeEvent) {

--- a/server/types.ts
+++ b/server/types.ts
@@ -53,6 +53,7 @@ export type MarkdocConfig = {
   typographer?: boolean;
   allowIndentation?: boolean;
   allowComments?: boolean;
+  validateFunctions?: boolean;
 };
 
 export type RoutingConfig = {


### PR DESCRIPTION

This PR changes the behavior of the table conversion code action so that it uses a code action resolver instead of a command. A conflict results when more than one instance of the language server registers a command with the same ID, so we can't register a command with a constant name during language server initialization.

In order to use commands for something like this, we'd need to append some unique identifier to the command ID. In this specific case, using a resolver to decouple the edit from the code action provider seemed like a more idiomatic solution.

This PR also updates the version of Markdoc and introduces support for the `config.validation.environment` variable, defaulting its value to `language-server`. This allows custom validation functions to identify the context in which they are being executed.