### PR TITLE
Adds partial codeactions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "Markdoc Extension",
   "author": "Ryan Paul",
   "license": "MIT",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "build": "esbuild index.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs",
     "build:server": "esbuild server.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Ryan Paul",
   "publisher": "stripe",
   "license": "MIT",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A Markdoc language server and Visual Studio Code extension",
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdoc/language-server",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A Markdoc language server",
   "main": "dist/index.js",
   "author": "Ryan Paul",

--- a/server/plugins/codeaction.ts
+++ b/server/plugins/codeaction.ts
@@ -32,30 +32,72 @@ export default class CodeActionProvider {
     }
   }
 
-  findTables(ast: Markdoc.Node, params: LSP.CodeActionParams): LSP.CodeAction[] {
+  async inlinePartial(uri: string, line: number, file: string): Promise<LSP.WorkspaceEdit | void> {
+    const ast = this.services.Documents.ast(uri);
+    if (!ast) return;
+
+    for (const node of ast.walk()) {
+      if (node.tag === 'partial' && node.lines[0] === line && !node.attributes.variables) {
+        const fullPath = this.services.Scanner.fullPath(file);
+        const newText = await this.services.Scanner.read(fullPath);
+        const [start, end] = node.lines;
+        const range = LSP.Range.create(start, 0, end, 0);
+        return {changes: {[uri]: [{range, newText}]}};
+      }
+    }
+  }
+  
+  findActions(ast: Markdoc.Node, params: LSP.CodeActionParams): LSP.CodeAction[] {
     const output: LSP.CodeAction[] = []; 
     const {line} = params.range.start;
     const {uri} = params.textDocument;
+
+    if (params.range.end.line - params.range.start.line > 3)
+      output.push({
+        title: 'Extract content to new partial',
+        command: LSP.Command.create('Extract Partial', 'markdoc.extractPartial')
+      });
     
-    for (const node of ast.walk())
-      if (node.type === 'table' && node.lines.includes(line))
+    for (const node of ast.walk()) {
+      if (node.type === 'table' && node.lines.includes(line)) {
         output.push({
           data: {type: 'convertTable', uri, line},
           title: 'Convert to Markdoc Table',
         });
+
+        continue;
+      }
+
+      if (node.tag === 'partial' && node.lines[0] === line && !node.attributes.variables) {
+        output.push({
+          data: {type: 'inlinePartial', uri, line, file: node.attributes.file},
+          title: 'Inline contents of this partial',
+        });
+        
+        continue;
+      }
+    }
 
     return output;
   }
 
   onCodeAction(params: LSP.CodeActionParams): (LSP.CodeAction | LSP.Command)[] {
     const ast = this.services.Documents.ast(params.textDocument.uri);
-    return ast ? this.findTables(ast, params) : [];
+    return ast ? this.findActions(ast, params) : [];
   }
 
-  onCodeActionResolve(action: LSP.CodeAction): LSP.CodeAction {
+  async onCodeActionResolve(action: LSP.CodeAction): Promise<LSP.CodeAction> {
+    if (!action.data?.type) return action;
+
     if (action.data.type === 'convertTable') {
       const {uri, line} = action.data;
       const edit = this.convertTable(uri, line);
+      if (edit) return {...action, edit};
+    }
+
+    if (action.data.type === 'inlinePartial') {
+      const {uri, line, file} = action.data;
+      const edit = await this.inlinePartial(uri, line, file);
       if (edit) return {...action, edit};
     }
 


### PR DESCRIPTION
This PR introduces two new code actions for partials: one that extracts the selected content into a new partial, and one that moves the content of a partial into the current document.