### PR TITLE
Improves the partial panel

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "Markdoc Extension",
   "author": "Ryan Paul",
   "license": "MIT",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "scripts": {
     "build": "esbuild index.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs",
     "build:server": "esbuild server.ts --bundle --outdir=dist --sourcemap=linked --external:vscode --platform=node --format=cjs"

--- a/client/partials.ts
+++ b/client/partials.ts
@@ -1,8 +1,11 @@
 import * as VSC from "vscode";
 import { DependencyInfo, PartialReference } from "../server/types";
 
+type PartialTreeRoot = { title: string; children?: PartialReference[] };
+type PartialTreeItem = PartialTreeRoot | PartialReference;
+
 export default class PartialTreeProvider
-  implements VSC.TreeDataProvider<PartialReference>
+  implements VSC.TreeDataProvider<PartialTreeItem>
 {
   private info?: DependencyInfo;
   private uri?: VSC.Uri;
@@ -10,14 +13,24 @@ export default class PartialTreeProvider
   private updateEmitter = new VSC.EventEmitter<void>();
   readonly onDidChangeTreeData = this.updateEmitter.event;
 
-  update(info: DependencyInfo, uri: VSC.Uri) {
+  update(info: DependencyInfo | undefined, uri: VSC.Uri) {
     this.info = info;
     this.uri = uri;
     this.updateEmitter.fire();
   }
 
-  getTreeItem(element: PartialReference): VSC.TreeItem {
+  getTreeItem(element: PartialTreeItem): VSC.TreeItem {
     if (!this.uri) return {};
+
+    if ("title" in element) {
+      const item = new VSC.TreeItem(element.title);
+      item.collapsibleState =
+        element?.children && element.children.length > 0
+          ? VSC.TreeItemCollapsibleState.Expanded
+          : VSC.TreeItemCollapsibleState.None;
+      return item;
+    }
+
     const uri = VSC.Uri.joinPath(this.uri, element.file);
     const item = new VSC.TreeItem(element.file);
     item.command = { command: "vscode.open", title: "Open", arguments: [uri] };
@@ -31,14 +44,22 @@ export default class PartialTreeProvider
   }
 
   getChildren(
-    element?: PartialReference
-  ): VSC.ProviderResult<PartialReference[]> {
-    return element
-      ? element.children
-      : !this.info
-      ? null
-      : this.info.dependents.length > 0
-      ? this.info.dependents
-      : this.info.dependencies;
+    element?: PartialTreeItem
+  ): VSC.ProviderResult<PartialTreeItem[]> {
+    if (element) return element.children;
+    if (!this.info) return [{ title: "Loading..." }];
+
+    const rootElements = [];
+    const { dependencies, dependents } = this.info;
+
+    if (dependencies.length > 0)
+      rootElements.push({ title: "Partials", children: dependencies });
+
+    if (dependents.length > 0)
+      rootElements.push({ title: "References", children: dependents });
+
+    if (rootElements.length < 1) rootElements.push({ title: "None" });
+
+    return rootElements;
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Ryan Paul",
   "publisher": "stripe",
   "license": "MIT",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A Markdoc language server and Visual Studio Code extension",
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdoc/language-server",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A Markdoc language server",
   "main": "dist/index.js",
   "author": "Ryan Paul",


### PR DESCRIPTION
- Improves the partials panel to add dedicated "partials" and "references" top-level tree elements so that both are shown at once. Previously, it would only show the partials if the doc is a route and the references if the doc is a partial — not both at once. This led to confusion about what was actually showing up in the panel.
- Improves the loading behavior of the partial tree panel so that it displays a loading message while the language server is still computing the contents and then updates when the contents are available. Previously, it would just show empty content during loading and would not update until the active tab changed.
- Makes the panel explicitly show "None" when the doc has no partials or references. 

<img width="421" alt="image" src="https://github.com/markdoc/language-server/assets/23323754/d5b2c8b9-5edc-4367-a404-f11f232ba0bb">
