### PR TITLE
Allow Language Server to be used as standalone process independent of VS Code Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ When using the server standalone without the client VS Code extension you can pa
 }
 ```
 
+Invoke the server with `markdoc-ls --stdio` from within your LSP client.
+
 ### File extensions
 
 In order to distinguish Markdoc files from Markdown files, the Visual Studio Code extension expects Markdoc files to use one of the following file extensions: `.markdoc`, `.markdoc.md`, or `.mdoc`.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ The JSON configuration file consists of an array of server instance descriptions
   - The `routing` property is an optional object that describes your project's routing configuration
     - The `frontmatter` property is a string that tells the extension which property in the Markdoc file's YAML frontmatter contains the URL route associated with the file
 
+### Standalone Server Configuration
+
+When using the server standalone without the client VS Code extension you can pass the configuration object to your LSP client like so:
+
+```json
+{
+  "root": "/path/to/project/root",
+  "path": "relative/path/to/markdoc/files",
+  "config": {
+    "root": "/path/to/project/root",
+    "path": "relative/path/to/markdoc/files"
+  }
+}
+```
+
 ### File extensions
 
 In order to distinguish Markdoc files from Markdown files, the Visual Studio Code extension expects Markdoc files to use one of the following file extensions: `.markdoc`, `.markdoc.md`, or `.mdoc`.

--- a/build.mjs
+++ b/build.mjs
@@ -2,12 +2,13 @@ import {context, build} from 'esbuild';
 
 const config = {
   bundle: true,
-  entryPoints: ['client/index.ts', 'server/index.ts', 'client/server.ts'],
+  entryPoints: ['client/index.ts', 'server/index.ts', 'server/wrapper.ts', 'client/server.ts'],
   outdir: 'dist',
   sourcemap: 'linked',
   external: ['vscode'],
   platform: 'node',
   format: 'cjs',
+  banner: { js: '#!/usr/bin/env node' },
 };
 
 if (process.argv.includes('--watch')) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "url": "https://github.com/markdoc/language-server.git"
   },
   "main": "./dist/client/index.js",
+  "bin": {
+    "markdoc-ls": "dist/server/wrapper.js"
+  },
   "scripts": {
     "build": "node build.mjs",
     "build:watch": "node build.mjs --watch",

--- a/server/package.json
+++ b/server/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "@markdoc/language-server",
+  "name": "@fjorn/markdoc-ls",
   "version": "0.0.12",
   "description": "A Markdoc language server",
   "main": "dist/index.js",
   "author": "Ryan Paul",
   "license": "MIT",
+  "bin": {
+    "markdoc-ls": "dist/wrapper.js"
+  },
   "devDependencies": {
     "@markdoc/markdoc": "^0.3.3",
     "@types/picomatch": "^2.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fjorn/markdoc-ls",
+  "name": "@markdoc/language-server",
   "version": "0.0.12",
   "description": "A Markdoc language server",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -5,9 +5,6 @@
   "main": "dist/index.js",
   "author": "Ryan Paul",
   "license": "MIT",
-  "bin": {
-    "markdoc-ls": "dist/wrapper.js"
-  },
   "devDependencies": {
     "@markdoc/markdoc": "^0.3.3",
     "@types/picomatch": "^2.3.0",

--- a/server/server.ts
+++ b/server/server.ts
@@ -29,8 +29,9 @@ export function connect(
   });
 
   return new Promise((resolve) => {
-    connection.onInitialized(() => resolve(options));
+    const options = connection.onInitialized(() => resolve(options));
     connection.listen();
+    return options
   });
 }
 

--- a/server/wrapper.ts
+++ b/server/wrapper.ts
@@ -1,0 +1,3 @@
+import { server } from './server';
+
+server();


### PR DESCRIPTION
I was trying to setup the [Markdoc Language Server](https://github.com/markdoc/language-server) for use with Helix (terminal based editor like nvim) but ran into issues. Installing the package with `npm install -g @markdoc/language-server` lead to no language server binary or script being accessible via the npm `bin` directory.

After investigating the source code I found it was because there was no build target for a standalone process running the language server. However, even after adding such a build target and installing the target to my npm global bin the server was not working. After digging around through the code I made 2 core discoveries:

1. The expected config the LSP client provides to the server requires redundant nesting (see README changes)
    - This is hidden from VS Code users as the extension generates the nesting from the VS Code config
2. The server code contained a bug while reading the config (see `server/server.ts:32` changes)
    - I'm unsure how the VS Code extension is even functional as without my patch the server threw an error at line 48 while reading `options.config` as `options` was undefined due to a bug in the `connect` function

I don't think my PR follows best practices for building/bundling an npm package intended to be installed globally for it's binaries but I think it generally gets the idea across and can be used as a jumping off point.