### PR TITLE
Fixes file watcher

### DIFF
--- a/server/plugins/watch.ts
+++ b/server/plugins/watch.ts
@@ -25,9 +25,11 @@ export default class Watch {
   }
 
   onContentChange(changes: FileWatchEvent[]) {
-    for (const change of changes)
+    for (const change of changes) {
+      const path = pathutil.join(this.config.root, change.path);
       if (change.type === LSP.FileChangeType.Deleted)
-        this.services.Scanner.delete(change.path);
-      else this.services.Scanner.update(change.path);
+        this.services.Scanner.delete(path);
+      else this.services.Scanner.update(path);
+    }
   }
 }


### PR DESCRIPTION
The file watcher gets a path that is relative to the **content** root and then passes that into the scanner, but the scanner expects either a path that is relative to the **workspace** root or an absolute path. This was resulting in files that are added or deleted after completion of the initial scan not being correctly added or removed in the in-memory file index.

This change makes it so that an absolute path gets passed to `Scanner.update` and `Scanner.delete` so that it works as expected.