### PR TITLE
Fix bug with overriding options object

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -29,7 +29,7 @@ export function connect(
   });
 
   return new Promise((resolve) => {
-    const options = connection.onInitialized(() => resolve(options));
+    connection.onInitialized(() => resolve(options));
     connection.listen();
     return options
   });


### PR DESCRIPTION
Recently, with the addition of supporting running LSP as a standalone process, the `connect` function was changed.

This changed the promise such that the options object was now the result of the `connection.onInitialized` function rather than the result of the callback from `connection.onInitialize`, which seems like an error in understanding the API of the LSP library

This reverts that change, but still returns the value options out of the promise, though it is likely an uneeded change.

Automated testing for this would be ideal, but as there doesn't seem to be any infrastructure for that currently, that is out of scope of this commit