### PR TITLE
Add OVSX publish step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npx vsce publish -p ${{ secrets.VSCODE_MARKET_TOKEN }}
+      - run: npx ovsx publish -p ${{ secrets.OVSX_PAT }}
       - run: cp -r dist/server server/dist # Move server build into server dir
       - run: cp README.md server
       - run: npm publish --access public


### PR DESCRIPTION
Closes https://github.com/markdoc/markdoc/issues/595

Uses the `ovsx` package to publish to the Open VSX Marketplace to make the extension available in VS Code compatible editors, such as Cursor.

You'll need to signup, sign the publisher agreement, and get an access token. [Docs here](https://github.com/EclipseFdn/open-vsx.org/wiki/Publishing-Extensions).